### PR TITLE
Properly add type hints for custom palette colors

### DIFF
--- a/libs/components/src/lib/EventTags.tsx
+++ b/libs/components/src/lib/EventTags.tsx
@@ -17,10 +17,7 @@ export function EventTags({ event }: { event: any }) {
         const IconComponent = tag.icon;
         return (
           <Grid key={tag.slug}>
-            <Chip
-              icon={<IconComponent />}
-              label={tag.name} /* color={tag.slug} */
-            />
+            <Chip icon={<IconComponent />} label={tag.name} color={tag.slug} />
           </Grid>
         );
       })}

--- a/libs/components/src/lib/EventsView.tsx
+++ b/libs/components/src/lib/EventsView.tsx
@@ -33,13 +33,13 @@ export function EventsView({ favoritesOnly }: { favoritesOnly: boolean }) {
         return getDefaultFilters();
       }
       const storedFilters = JSON.parse(
-        localStorage.getItem('lastFilters') || '[]'
+        localStorage.getItem('lastFilters') || '[]',
       );
       if (storedFilters === null) {
         return getDefaultFilters();
       }
       return Object.fromEntries(
-        TAGS.map((tag) => [tag.slug, !!storedFilters[tag.slug]])
+        TAGS.map((tag) => [tag.slug, !!storedFilters[tag.slug]]),
       );
     } catch (err) {
       console.error(err);
@@ -72,16 +72,16 @@ export function EventsView({ favoritesOnly }: { favoritesOnly: boolean }) {
         (a, b) =>
           a.starting.unix() - b.starting.unix() || // Sort first by start time
           a.ending.unix() - b.ending.unix() || // Then by earliest end time
-          a.event.title.localeCompare(b.event.title) // Then alphabetically
+          a.event.title.localeCompare(b.event.title), // Then alphabetically
       ),
-    [eventTimes]
+    [eventTimes],
   );
 
   const filteredEventTimes = useMemo(() => {
     const preFilteredEventTimes = sortedEventTimes?.filter(
       (eventTime) =>
         eventTime.day_of_week === selectedDay &&
-        (!favoritesOnly || favoriteEventTimeIds.has(eventTime.event_time_id))
+        (!favoritesOnly || favoriteEventTimeIds.has(eventTime.event_time_id)),
     );
     const selectedTagSlugs = TAGS.reduce((acc, tag) => {
       if (filters[tag.slug]) {
@@ -93,7 +93,7 @@ export function EventsView({ favoritesOnly }: { favoritesOnly: boolean }) {
       return preFilteredEventTimes;
     }
     return preFilteredEventTimes?.filter((eventTime: any) =>
-      [...selectedTagSlugs].some((slug) => eventTime.event[slug])
+      [...selectedTagSlugs].some((slug) => eventTime.event[slug]),
     );
   }, [
     sortedEventTimes,
@@ -191,7 +191,7 @@ export function EventsView({ favoritesOnly }: { favoritesOnly: boolean }) {
                 variant={filters[tag.slug] ? 'filled' : 'outlined'}
                 icon={<IconComponent />}
                 label={tag.name}
-                // color={tag.slug}
+                color={tag.slug}
               />
             </Grid>
           );

--- a/libs/types/src/lib/tags.ts
+++ b/libs/types/src/lib/tags.ts
@@ -2,7 +2,14 @@ import { SvgIconTypeMap } from '@mui/material';
 import { OverridableComponent } from '@mui/material/OverridableComponent';
 
 export interface TagItem {
-  slug: string;
+  slug:
+    | 'alcohol'
+    | 'crafting'
+    | 'fire_art'
+    | 'food'
+    | 'red_light'
+    | 'sober'
+    | 'spectacle';
   name: string;
   icon: OverridableComponent<SvgIconTypeMap<object, 'svg'>> & {
     muiName: string;

--- a/libs/utils/src/lib/theme.ts
+++ b/libs/utils/src/lib/theme.ts
@@ -1,6 +1,40 @@
 'use client';
 import { createTheme } from '@mui/material/styles';
 
+declare module '@mui/material/styles' {
+  interface Palette {
+    alcohol: Palette['primary'];
+    crafting: Palette['primary'];
+    fire_art: Palette['primary'];
+    food: Palette['primary'];
+    red_light: Palette['primary'];
+    sober: Palette['primary'];
+    spectacle: Palette['primary'];
+  }
+
+  interface PaletteOptions {
+    alcohol?: PaletteOptions['primary'];
+    crafting?: PaletteOptions['primary'];
+    fire_art?: PaletteOptions['primary'];
+    food?: PaletteOptions['primary'];
+    red_light?: PaletteOptions['primary'];
+    sober?: PaletteOptions['primary'];
+    spectacle?: PaletteOptions['primary'];
+  }
+}
+
+declare module '@mui/material/Chip' {
+  interface ChipPropsColorOverrides {
+    alcohol: true;
+    crafting: true;
+    fire_art: true;
+    food: true;
+    red_light: true;
+    sober: true;
+    spectacle: true;
+  }
+}
+
 const base = createTheme({
   typography: {
     fontFamily: 'var(--font-roboto)',


### PR DESCRIPTION
This PR adds the custom palette colors to the MUI Typescript definitions, as laid out here: https://mui.com/material-ui/customization/palette/#typescript