### PR TITLE
Specify start_url and use theme color

### DIFF
--- a/apps/digital-www-pwa/public/site.webmanifest
+++ b/apps/digital-www-pwa/public/site.webmanifest
@@ -1,6 +1,7 @@
 {
   "name": "Lakes of Fire 2025 Digital WWW",
   "short_name": "LoF 2025 WWW",
+  "start_url": "/",
   "icons": [
     {
       "src": "/android-chrome-192x192.png",
@@ -13,7 +14,7 @@
       "type": "image/png"
     }
   ],
-  "theme_color": "#ffffff",
+  "theme_color": "#ef4137",
   "background_color": "#ffffff",
   "display": "standalone"
 }


### PR DESCRIPTION
Small update. It looks like some browsers will only allow the PWA to be installed if start_url is specified:

https://developer.mozilla.org/en-US/docs/Web/Progressive_web_apps/Guides/Making_PWAs_installable#required_manifest_members