### PR TITLE
Fix for broken docker build

### DIFF
--- a/.yarnrc.yml
+++ b/.yarnrc.yml
@@ -1,3 +1,3 @@
 globalFolder: .yarn
-
+nodeLinker: node-modules
 yarnPath: .yarn/releases/yarn-4.9.1.cjs

--- a/apps/digital-www-pwa/Dockerfile
+++ b/apps/digital-www-pwa/Dockerfile
@@ -1,10 +1,13 @@
 FROM node:20-alpine AS builder
 RUN apk add --no-cache python3 make g++ && npm install -g node-gyp
+WORKDIR /opt
 COPY dist/apps/digital-www-pwa/package.json ./
-RUN npm install
+COPY .yarnrc.yml ./
+COPY .yarn/releases/yarn-4.9.1.cjs ./.yarn/releases/yarn-4.9.1.cjs
+RUN yarn install
 
 FROM node:20-alpine AS app
 USER node
-COPY --from=builder node_modules node_modules
+COPY --from=builder /opt/node_modules node_modules
 COPY dist/apps/digital-www-pwa .
 CMD ["npm", "start"]


### PR DESCRIPTION
- Update `.yarnrc.yml` to use `node_modules` as default linker
- Update Dockerfile to use current yarn berry version