### PR TITLE
Migrate to react-router

### DIFF
--- a/apps/digital-www-pwa/public/sw.js
+++ b/apps/digital-www-pwa/public/sw.js
@@ -36,7 +36,12 @@ const cacheClone = async (e) => {
     e.respondWith(
       cacheClone(e)
         .catch(() => caches.match(e.request))
-        .then((res) => res)
+        .then((res) => {
+          if (!res && e.request.destination === 'document') {
+            return caches.match('/');
+          }
+          return res;
+        })
     );
   });
 })();

--- a/apps/digital-www-pwa/src/app/art/[id]/page.tsx
+++ b/apps/digital-www-pwa/src/app/art/[id]/page.tsx
@@ -1,6 +1,5 @@
 'use client';
-import { ArtItemPage } from '@digital-www-pwa/pages';
 
 export default function Page({ params }: { params: { id: string } }) {
-  return <ArtItemPage id={params.id}></ArtItemPage>;
+  return null;
 }

--- a/apps/digital-www-pwa/src/app/art/page.tsx
+++ b/apps/digital-www-pwa/src/app/art/page.tsx
@@ -1,6 +1,5 @@
 'use client';
-import { ArtPage } from '@digital-www-pwa/pages';
 
 export default function Page() {
-  return <ArtPage />;
+  return null;
 }

--- a/apps/digital-www-pwa/src/app/camps/[id]/page.tsx
+++ b/apps/digital-www-pwa/src/app/camps/[id]/page.tsx
@@ -1,6 +1,5 @@
 'use client';
-import { CampsItemPage } from '@digital-www-pwa/pages';
 
 export default function Page({ params }: { params: { id: string } }) {
-  return <CampsItemPage id={params.id} />;
+  return null;
 }

--- a/apps/digital-www-pwa/src/app/camps/page.tsx
+++ b/apps/digital-www-pwa/src/app/camps/page.tsx
@@ -1,6 +1,5 @@
 'use client';
-import { CampsPage } from '@digital-www-pwa/pages';
 
 export default function Page() {
-  return <CampsPage />;
+  return null;
 }

--- a/apps/digital-www-pwa/src/app/events/[id]/page.tsx
+++ b/apps/digital-www-pwa/src/app/events/[id]/page.tsx
@@ -1,6 +1,5 @@
 'use client';
-import { EventsItemPage } from '@digital-www-pwa/pages';
 
 export default function Page({ params }: { params: { id: string } }) {
-  return <EventsItemPage id={params.id} />;
+  return null;
 }

--- a/apps/digital-www-pwa/src/app/events/page.tsx
+++ b/apps/digital-www-pwa/src/app/events/page.tsx
@@ -1,6 +1,5 @@
 'use client';
-import { EventsPage } from '@digital-www-pwa/pages';
 
 export default function Page() {
-  return <EventsPage />;
+  return null;
 }

--- a/apps/digital-www-pwa/src/app/favorites/page.tsx
+++ b/apps/digital-www-pwa/src/app/favorites/page.tsx
@@ -1,6 +1,5 @@
 'use client';
-import { FavoritesPage } from '@digital-www-pwa/pages';
 
 export default function Page() {
-  return <FavoritesPage />;
+  return null;
 }

--- a/apps/digital-www-pwa/src/app/layout.tsx
+++ b/apps/digital-www-pwa/src/app/layout.tsx
@@ -2,7 +2,7 @@
 import { ThemeProvider } from '@mui/material';
 import CssBaseline from '@mui/material/CssBaseline';
 import { useEffect } from 'react';
-import { BrowserRouter, Routes, Route } from 'react-router';
+import { MemoryRouter, BrowserRouter, Routes, Route } from 'react-router';
 
 import { AppShell, HeadComponent } from '@digital-www-pwa/components';
 import {
@@ -47,19 +47,15 @@ export default function RootLayout() {
     }
   }, []);
 
-  if (typeof document === 'undefined')
-    return (
-      <html>
-        <body />
-      </html>
-    );
+  const RouterComponent =
+    typeof document === 'undefined' ? MemoryRouter : BrowserRouter;
 
   return (
     <ThemeProvider theme={theme}>
       <html lang="en">
         <HeadComponent />
         <body style={{ fontFamily: theme.typography.fontFamily }}>
-          <BrowserRouter>
+          <RouterComponent>
             <CssBaseline />
             <AuthProvider>
               <FeedProvider>
@@ -125,7 +121,7 @@ export default function RootLayout() {
                 </StorageProvider>
               </FeedProvider>
             </AuthProvider>
-          </BrowserRouter>
+          </RouterComponent>
         </body>
       </html>
     </ThemeProvider>

--- a/apps/digital-www-pwa/src/app/layout.tsx
+++ b/apps/digital-www-pwa/src/app/layout.tsx
@@ -55,11 +55,11 @@ export default function RootLayout() {
     );
 
   return (
-    <html lang="en">
-      <HeadComponent />
-      <body style={{ fontFamily: 'Quattrocento' }}>
-        <BrowserRouter>
-          <ThemeProvider theme={theme}>
+    <ThemeProvider theme={theme}>
+      <html lang="en">
+        <HeadComponent />
+        <body style={{ fontFamily: 'Quattrocento' }}>
+          <BrowserRouter>
             <CssBaseline />
             <AuthProvider>
               <FeedProvider>
@@ -125,9 +125,9 @@ export default function RootLayout() {
                 </StorageProvider>
               </FeedProvider>
             </AuthProvider>
-          </ThemeProvider>
-        </BrowserRouter>
-      </body>
-    </html>
+          </BrowserRouter>
+        </body>
+      </html>
+    </ThemeProvider>
   );
 }

--- a/apps/digital-www-pwa/src/app/layout.tsx
+++ b/apps/digital-www-pwa/src/app/layout.tsx
@@ -1,10 +1,28 @@
 'use client';
 import { ThemeProvider } from '@mui/material';
 import CssBaseline from '@mui/material/CssBaseline';
-import { AppRouterCacheProvider } from '@mui/material-nextjs/v15-appRouter';
 import { useEffect } from 'react';
+import { BrowserRouter, Routes, Route } from 'react-router';
 
 import { AppShell, HeadComponent } from '@digital-www-pwa/components';
+import {
+  HomePage,
+  EventsPage,
+  ArtPage,
+  ArtItemPage,
+  CampsPage,
+  CampsItemPage,
+  HappeningNowPage,
+  MapPage,
+  RadioPage,
+  RadioItemPage,
+  ShiftsPage,
+  ShiftPage,
+  VehiclesPage,
+  VehiclesItemPage,
+  EventsItemPage,
+  FavoritesPage,
+} from '@digital-www-pwa/pages';
 import {
   FavoritesProvider,
   FeedProvider,
@@ -20,11 +38,7 @@ import '@fontsource/quattrocento';
 import '@fontsource/cinzel';
 import '@fontsource/cinzel-decorative';
 
-export default function RootLayout({
-  children,
-}: {
-  children: React.ReactNode;
-}) {
+export default function RootLayout() {
   useEffect(() => {
     if ('serviceWorker' in navigator) {
       navigator.serviceWorker
@@ -33,11 +47,18 @@ export default function RootLayout({
     }
   }, []);
 
+  if (typeof document === 'undefined')
+    return (
+      <html>
+        <body />
+      </html>
+    );
+
   return (
     <html lang="en">
       <HeadComponent />
       <body style={{ fontFamily: 'Quattrocento' }}>
-        <AppRouterCacheProvider>
+        <BrowserRouter>
           <ThemeProvider theme={theme}>
             <CssBaseline />
             <AuthProvider>
@@ -47,7 +68,56 @@ export default function RootLayout({
                     <ProcessedDataProvider>
                       <SearchIndexProvider>
                         <GeolocationProvider>
-                          <AppShell>{children}</AppShell>
+                          <AppShell>
+                            <Routes>
+                              <Route path="/events" element={<EventsPage />} />
+                              <Route
+                                path="/events/:id"
+                                element={<EventsItemPage />}
+                              />
+                              <Route
+                                path="/favorites"
+                                element={<FavoritesPage />}
+                              />
+                              <Route path="/art" element={<ArtPage />} />
+                              <Route
+                                path="/art/:id"
+                                element={<ArtItemPage />}
+                              />
+                              <Route path="/camps" element={<CampsPage />} />
+                              <Route
+                                path="/camps/:id"
+                                element={<CampsItemPage />}
+                              />
+                              <Route path="/radio" element={<RadioPage />} />
+                              <Route
+                                path="/radio/:id"
+                                element={<RadioItemPage />}
+                              />
+                              <Route
+                                path="/vehicles"
+                                element={<VehiclesPage />}
+                              />
+                              <Route
+                                path="/vehicles/:id"
+                                element={<VehiclesItemPage />}
+                              />
+                              <Route
+                                path="/volunteer-shifts"
+                                element={<ShiftsPage />}
+                              />
+                              <Route
+                                path="/shift/:id"
+                                element={<ShiftPage />}
+                              />
+                              <Route path="/map" element={<MapPage />} />
+                              <Route
+                                path="/now"
+                                element={<HappeningNowPage />}
+                              />
+                              <Route index element={<HomePage />} />
+                            </Routes>
+                          </AppShell>
                         </GeolocationProvider>
                       </SearchIndexProvider>
                     </ProcessedDataProvider>
@@ -56,7 +126,7 @@ export default function RootLayout({
               </FeedProvider>
             </AuthProvider>
           </ThemeProvider>
-        </AppRouterCacheProvider>
+        </BrowserRouter>
       </body>
     </html>
   );

--- a/apps/digital-www-pwa/src/app/layout.tsx
+++ b/apps/digital-www-pwa/src/app/layout.tsx
@@ -58,7 +58,7 @@ export default function RootLayout() {
     <ThemeProvider theme={theme}>
       <html lang="en">
         <HeadComponent />
-        <body style={{ fontFamily: 'Quattrocento' }}>
+        <body style={{ fontFamily: theme.typography.fontFamily }}>
           <BrowserRouter>
             <CssBaseline />
             <AuthProvider>

--- a/apps/digital-www-pwa/src/app/layout.tsx
+++ b/apps/digital-www-pwa/src/app/layout.tsx
@@ -49,6 +49,7 @@ export default function RootLayout() {
 
   const RouterComponent =
     typeof document === 'undefined' ? MemoryRouter : BrowserRouter;
+  const RoutesComponent = typeof document === 'undefined' ? () => null : Routes;
 
   return (
     <ThemeProvider theme={theme}>
@@ -65,7 +66,7 @@ export default function RootLayout() {
                       <SearchIndexProvider>
                         <GeolocationProvider>
                           <AppShell>
-                            <Routes>
+                            <RoutesComponent>
                               <Route path="/events" element={<EventsPage />} />
                               <Route
                                 path="/events/:id"
@@ -112,7 +113,7 @@ export default function RootLayout() {
                                 element={<HappeningNowPage />}
                               />
                               <Route index element={<HomePage />} />
-                            </Routes>
+                            </RoutesComponent>
                           </AppShell>
                         </GeolocationProvider>
                       </SearchIndexProvider>

--- a/apps/digital-www-pwa/src/app/map/page.tsx
+++ b/apps/digital-www-pwa/src/app/map/page.tsx
@@ -1,6 +1,5 @@
 'use client';
-import { MapPage } from '@digital-www-pwa/pages';
 
 export default function Page() {
-  return <MapPage />;
+  return null;
 }

--- a/apps/digital-www-pwa/src/app/now/page.tsx
+++ b/apps/digital-www-pwa/src/app/now/page.tsx
@@ -1,6 +1,5 @@
 'use client';
-import { HappeningNowPage } from '@digital-www-pwa/pages';
 
 export default function Page() {
-  return <HappeningNowPage />;
+  return null;
 }

--- a/apps/digital-www-pwa/src/app/page.tsx
+++ b/apps/digital-www-pwa/src/app/page.tsx
@@ -1,6 +1,5 @@
 'use client';
-import { HomePage } from '@digital-www-pwa/pages';
 
 export default function Index() {
-  return <HomePage />;
+  return null;
 }

--- a/apps/digital-www-pwa/src/app/radio/[id]/page.tsx
+++ b/apps/digital-www-pwa/src/app/radio/[id]/page.tsx
@@ -1,6 +1,5 @@
 'use client';
-import { RadioItemPage } from '@digital-www-pwa/pages';
 
 export default function Page({ params }: { params: { id: string } }) {
-  return <RadioItemPage id={params.id} />;
+  return null;
 }

--- a/apps/digital-www-pwa/src/app/radio/page.tsx
+++ b/apps/digital-www-pwa/src/app/radio/page.tsx
@@ -1,6 +1,5 @@
 'use client';
-import { RadioPage } from '@digital-www-pwa/pages';
 
 export default function Page() {
-  return <RadioPage />;
+  return null;
 }

--- a/apps/digital-www-pwa/src/app/shift/[id]/page.tsx
+++ b/apps/digital-www-pwa/src/app/shift/[id]/page.tsx
@@ -1,6 +1,5 @@
 'use client';
-import { ShiftPage } from '@digital-www-pwa/pages';
 
 export default function Page({ params }: { params: { id: string } }) {
-  return <ShiftPage id={params.id} />;
+  return null;
 }

--- a/apps/digital-www-pwa/src/app/vehicles/[id]/page.tsx
+++ b/apps/digital-www-pwa/src/app/vehicles/[id]/page.tsx
@@ -1,6 +1,5 @@
 'use client';
-import { VehiclesItemPage } from '@digital-www-pwa/pages';
 
 export default function Page({ params }: { params: { id: string } }) {
-  return <VehiclesItemPage id={params.id} />;
+  return null;
 }

--- a/apps/digital-www-pwa/src/app/vehicles/page.tsx
+++ b/apps/digital-www-pwa/src/app/vehicles/page.tsx
@@ -1,6 +1,5 @@
 'use client';
-import { VehiclesPage } from '@digital-www-pwa/pages';
 
 export default function Page() {
-  return <VehiclesPage />;
+  return null;
 }

--- a/apps/digital-www-pwa/src/app/volunteer-shifts/page.tsx
+++ b/apps/digital-www-pwa/src/app/volunteer-shifts/page.tsx
@@ -1,6 +1,5 @@
 'use client';
-import { ShiftsPage } from '@digital-www-pwa/pages';
 
 export default function Page() {
-  return <ShiftsPage />;
+  return null;
 }

--- a/apps/digital-www-pwa/src/app/week-view/page.tsx
+++ b/apps/digital-www-pwa/src/app/week-view/page.tsx
@@ -1,6 +1,0 @@
-'use client';
-import { WeekViewPage } from '@digital-www-pwa/pages';
-
-export default function Page() {
-  return <WeekViewPage />;
-}

--- a/libs/components/src/lib/AppBar.tsx
+++ b/libs/components/src/lib/AppBar.tsx
@@ -43,7 +43,7 @@ export function AppBar() {
         aria-label="menu"
         onClick={() => setOpen(!open)}
       >
-        <MenuIcon />
+        <MenuIcon sx={{ width: '1.5em', height: '1.5em' }} />
       </IconButton>
     );
   }
@@ -59,8 +59,9 @@ export function AppBar() {
         color="inherit"
         aria-label="menu"
         onClick={() => navigate(-1)}
+        sx={{ marginRight: (theme) => theme.spacing(2) }}
       >
-        <ArrowBackIcon />
+        <ArrowBackIcon sx={{ width: '1.5em', height: '1.5em' }} />
       </IconButton>
     );
   }

--- a/libs/components/src/lib/AppBar.tsx
+++ b/libs/components/src/lib/AppBar.tsx
@@ -1,7 +1,11 @@
 'use client';
 import { AuthNav, SearchButton } from '@digital-www-pwa/components';
 import { useAuthContext } from '@digital-www-pwa/providers';
-import { NAVIGATION_LINKS } from '@digital-www-pwa/utils';
+import {
+  NAVIGATION_LINKS,
+  EVENT_START,
+  EVENT_END,
+} from '@digital-www-pwa/utils';
 import ArrowBackIcon from '@mui/icons-material/ArrowBack';
 import HomeIcon from '@mui/icons-material/Home';
 import MenuIcon from '@mui/icons-material/Menu';
@@ -18,6 +22,7 @@ import ListItemIcon from '@mui/material/ListItemIcon';
 import ListItemText from '@mui/material/ListItemText';
 import { useTheme } from '@mui/material/styles';
 import Toolbar from '@mui/material/Toolbar';
+import dayjs from 'dayjs';
 import { useState } from 'react';
 import { useNavigate, useLocation } from 'react-router';
 import { Link as RouterLink } from 'react-router';
@@ -111,6 +116,12 @@ export function AppBar() {
           <Divider />
           {!authContext.isAuthenticated && <AuthNav setOpen={setOpen} />}
           {NAVIGATION_LINKS.map((link) => {
+            if (
+              link.path === '/now' &&
+              !dayjs().isBetween(EVENT_START, EVENT_END)
+            ) {
+              return null;
+            }
             const IconComponent = link.icon;
             return (
               <ListItem key={link.path}>

--- a/libs/components/src/lib/AppBar.tsx
+++ b/libs/components/src/lib/AppBar.tsx
@@ -18,14 +18,14 @@ import ListItemIcon from '@mui/material/ListItemIcon';
 import ListItemText from '@mui/material/ListItemText';
 import { useTheme } from '@mui/material/styles';
 import Toolbar from '@mui/material/Toolbar';
-import NextLink from 'next/link';
-import { useRouter, usePathname } from 'next/navigation';
 import { useState } from 'react';
+import { useNavigate, useLocation } from 'react-router';
+import { Link as RouterLink } from 'react-router';
 
 export function AppBar() {
+  const navigate = useNavigate();
+  const location = useLocation();
   const [open, setOpen] = useState(false);
-  const router = useRouter();
-  const pathname = usePathname();
   const theme = useTheme();
   const authContext = useAuthContext();
 
@@ -44,7 +44,7 @@ export function AppBar() {
   }
 
   function renderBackButton() {
-    if (pathname.split('/').length <= 2) {
+    if (location.pathname.split('/').length <= 2) {
       return null;
     }
     return (
@@ -53,7 +53,7 @@ export function AppBar() {
         edge="start"
         color="inherit"
         aria-label="menu"
-        onClick={() => router.back()}
+        onClick={() => navigate(-1)}
       >
         <ArrowBackIcon />
       </IconButton>
@@ -74,8 +74,8 @@ export function AppBar() {
           <Toolbar sx={{ paddingLeft: 0, alignItems: 'center' }}>
             {renderBackButton()}
             <Link
-              component={NextLink}
-              href="/"
+              component={RouterLink}
+              to="/"
               style={{
                 display: 'flex',
                 flexGrow: 1,
@@ -98,8 +98,8 @@ export function AppBar() {
         <List>
           <ListItem>
             <ListItemButton
-              component={NextLink}
-              href="/"
+              component={RouterLink}
+              to="/"
               onClick={() => setOpen(false)}
             >
               <ListItemIcon>
@@ -115,8 +115,8 @@ export function AppBar() {
             return (
               <ListItem key={link.path}>
                 <ListItemButton
-                  component={NextLink}
-                  href={link.path}
+                  component={RouterLink}
+                  to={link.path}
                   onClick={() => setOpen(false)}
                 >
                   <ListItemIcon>

--- a/libs/components/src/lib/ArtCard.tsx
+++ b/libs/components/src/lib/ArtCard.tsx
@@ -7,13 +7,13 @@ import CardContent from '@mui/material/CardContent';
 import CardHeader from '@mui/material/CardHeader';
 import Grid from '@mui/material/Grid2';
 import Typography from '@mui/material/Typography';
-import Link from 'next/link';
+import { Link } from 'react-router';
 
 export function ArtCard({ art }: { art: ArtItem }) {
   return (
     <Grid size={{ xxs: 12, md: 6, lg: 4 }}>
       <Card>
-        <CardActionArea component={Link} href={`/art/${art.id}`}>
+        <CardActionArea component={Link} to={`/art/${art.id}`}>
           <CardHeader title={art.title} subheader={art.artist} />
           <CardContent>
             <Typography variant="subtitle1">

--- a/libs/components/src/lib/AuthNav.tsx
+++ b/libs/components/src/lib/AuthNav.tsx
@@ -6,13 +6,13 @@ import ListItem from '@mui/material/ListItem';
 import ListItemButton from '@mui/material/ListItemButton';
 import ListItemIcon from '@mui/material/ListItemIcon';
 import ListItemText from '@mui/material/ListItemText';
-import { usePathname } from 'next/navigation';
+import { useLocation } from 'react-router';
 
 export function AuthNav({ setOpen }: { setOpen: (arg0: boolean) => void }) {
+  const location = useLocation();
   const authContext = useAuthContext();
-  const pathname = usePathname();
   const queryParams = new URLSearchParams({
-    redirect_target: pathname,
+    redirect_target: location.pathname,
   });
 
   if (authContext.isAuthenticated) {

--- a/libs/components/src/lib/BackToTopButton.tsx
+++ b/libs/components/src/lib/BackToTopButton.tsx
@@ -45,7 +45,14 @@ export function BackToTopButton() {
     <Fade in={scrolledDown || lastScroll !== null}>
       <Fab
         size={fabSize}
-        sx={{ position: 'fixed', bottom: fabSpacing, right: fabSpacing }}
+        sx={{
+          position: 'fixed',
+          bottom: fabSpacing,
+          right: fabSpacing,
+          '@media print': {
+            display: 'none',
+          },
+        }}
         onClick={handleClick}
       >
         {lastScroll ? <KeyboardArrowDownIcon /> : <KeyboardArrowUpIcon />}

--- a/libs/components/src/lib/BackToTopButton.tsx
+++ b/libs/components/src/lib/BackToTopButton.tsx
@@ -6,12 +6,12 @@ import Fade from '@mui/material/Fade';
 import { useTheme } from '@mui/material/styles';
 import useMediaQuery from '@mui/material/useMediaQuery';
 import useScrollTrigger from '@mui/material/useScrollTrigger';
-import { usePathname } from 'next/navigation';
+import { useLocation } from 'react-router';
 import { useState, useLayoutEffect } from 'react';
 
 export function BackToTopButton() {
+  const location = useLocation();
   const theme = useTheme();
-  const pathname = usePathname();
   const [lastScroll, setLastScroll] = useState<number | null>(null);
   const scrolledDown = useScrollTrigger({
     disableHysteresis: true,
@@ -25,7 +25,7 @@ export function BackToTopButton() {
 
   useLayoutEffect(() => {
     setLastScroll(null);
-  }, [pathname]);
+  }, [location.pathname]);
 
   const handleClick = () => {
     if (lastScroll) {

--- a/libs/components/src/lib/CampCard.tsx
+++ b/libs/components/src/lib/CampCard.tsx
@@ -6,13 +6,13 @@ import CardContent from '@mui/material/CardContent';
 import CardHeader from '@mui/material/CardHeader';
 import Grid from '@mui/material/Grid2';
 import Typography from '@mui/material/Typography';
-import Link from 'next/link';
+import { Link } from 'react-router';
 
 export function CampCard({ camp }: { camp: CampItem }) {
   return (
     <Grid size={{ xxs: 12, md: 6, lg: 4 }}>
       <Card>
-        <CardActionArea component={Link} href={`/camps/${camp.id}`}>
+        <CardActionArea component={Link} to={`/camps/${camp.id}`}>
           <CardHeader title={camp.name} subheader={camp.location_name} />
           <CardContent>
             <Typography variant="subtitle1">

--- a/libs/components/src/lib/EventCard.tsx
+++ b/libs/components/src/lib/EventCard.tsx
@@ -7,7 +7,7 @@ import CardContent from '@mui/material/CardContent';
 import CardHeader from '@mui/material/CardHeader';
 import Grid from '@mui/material/Grid2';
 import Typography from '@mui/material/Typography';
-import Link from 'next/link';
+import { Link } from 'react-router';
 import { useTheme } from '@mui/material/styles';
 
 import { EventTags } from './EventTags';
@@ -20,7 +20,7 @@ export function EventCard({ eventTime }: { eventTime: ParsedEventTime }) {
       <Card sx={{ position: 'relative' }}>
         <CardActionArea
           component={Link}
-          href={`/events/${eventTime.event_time_id}`}
+          to={`/events/${eventTime.event_time_id}`}
         >
           <CardHeader
             title={eventTime.event.title}

--- a/libs/components/src/lib/EventTags.tsx
+++ b/libs/components/src/lib/EventTags.tsx
@@ -25,6 +25,7 @@ export function EventTags({ event }: { event?: ProcessedEventItem }) {
               sx={{
                 '@media print': {
                   background: 'none',
+                  color: 'initial',
                 },
               }}
             />

--- a/libs/components/src/lib/Head.tsx
+++ b/libs/components/src/lib/Head.tsx
@@ -1,5 +1,8 @@
 'use client';
+import { useTheme } from '@mui/material/styles';
+
 export function HeadComponent() {
+  const theme = useTheme();
   return (
     <head>
       <title>Lakes of Fire 2025 - Doorways in Time</title>
@@ -23,10 +26,11 @@ export function HeadComponent() {
         href="/favicon-16x16.png"
       />
       <link rel="manifest" href="/site.webmanifest" />
+      <link rel="preload" as="image" href="/map.jpg" />
       <meta name="format-detection" content="telephone=no" />
       <meta name="msapplication-tap-highlight" content="no" />
-      <meta name="msapplication-TileColor" content="#ffffff" />
-      <meta name="theme-color" content="#ffffff" />
+      <meta name="msapplication-TileColor" content={theme.palette.sky.main} />
+      <meta name="theme-color" content={theme.palette.sky.main} />
       <meta name="apple-mobile-web-app-capable" content="yes" />
       <meta name="apple-mobile-web-app-status-bar-style" content="white" />
       <meta name="mobile-web-app-capable" content="yes" />

--- a/libs/components/src/lib/Link.tsx
+++ b/libs/components/src/lib/Link.tsx
@@ -1,6 +1,6 @@
 'use client';
 import { useTopNavContext } from '@digital-www-pwa/providers';
-import { useRouter } from 'next/navigation';
+import { useNavigate } from 'react-router';
 
 interface LinkProps {
   to: string;
@@ -9,7 +9,7 @@ interface LinkProps {
 }
 
 export function Link({ to, className, children }: LinkProps) {
-  const router = useRouter();
+  const navigate = useNavigate();
   const { setExpanded } = useTopNavContext();
   return (
     <a
@@ -18,7 +18,7 @@ export function Link({ to, className, children }: LinkProps) {
       onClick={(e) => {
         e.preventDefault();
         setExpanded(false);
-        return router.push(to);
+        return navigate(to);
       }}
     >
       {children}

--- a/libs/components/src/lib/NavigationButton.tsx
+++ b/libs/components/src/lib/NavigationButton.tsx
@@ -1,7 +1,7 @@
 'use client';
 import type { NavigationLink } from '@digital-www-pwa/types';
 import Button from '@mui/material/Button';
-import RouterLink from 'next/link';
+import { Link as RouterLink } from 'react-router';
 
 export function NavigationButton({ linkData }: { linkData: NavigationLink }) {
   const getAnimation = () => {
@@ -15,7 +15,7 @@ export function NavigationButton({ linkData }: { linkData: NavigationLink }) {
   return (
     <Button
       component={RouterLink}
-      href={linkData.path}
+      to={linkData.path}
       sx={{
         '@keyframes breathing': {
           '0%': {

--- a/libs/components/src/lib/RadioCard.tsx
+++ b/libs/components/src/lib/RadioCard.tsx
@@ -7,13 +7,13 @@ import CardContent from '@mui/material/CardContent';
 import CardHeader from '@mui/material/CardHeader';
 import Grid from '@mui/material/Grid2';
 import Typography from '@mui/material/Typography';
-import Link from 'next/link';
+import { Link } from 'react-router';
 
 export function RadioCard({ radio }: { radio: ProcessedRadioItem }) {
   return (
     <Grid size={{ xxs: 12, md: 6, lg: 4 }}>
       <Card>
-        <CardActionArea component={Link} href={`/radio/${radio.id}`}>
+        <CardActionArea component={Link} to={`/radio/${radio.id}`}>
           <CardHeader
             title={radio.radio_dj_name}
             subheader={radio.radio_time.format('LT')}

--- a/libs/components/src/lib/SearchButton.tsx
+++ b/libs/components/src/lib/SearchButton.tsx
@@ -12,12 +12,14 @@ export function SearchButton() {
     <>
       <IconButton
         ref={anchorRef}
+        size="large"
         edge="end"
         color="inherit"
         aria-label="clear"
         onClick={() => setSearchOpen(!searchOpen)}
+        sx={{ marginLeft: (theme) => theme.spacing(2) }}
       >
-        <SearchIcon />
+        <SearchIcon sx={{ width: '1.5em', height: '1.5em' }} />
       </IconButton>
       <SearchWindow
         open={searchOpen}

--- a/libs/components/src/lib/SearchResults.tsx
+++ b/libs/components/src/lib/SearchResults.tsx
@@ -9,7 +9,7 @@ import {
 import MenuItem from '@mui/material/MenuItem';
 import MenuList from '@mui/material/MenuList';
 import lunr from 'lunr';
-import Link from 'next/link';
+import { Link } from 'react-router';
 import { useMemo } from 'react';
 
 import { ArtSearchResult } from './ArtSearchResult';
@@ -104,7 +104,7 @@ export function SearchResults({
           <MenuItem
             key={result.href}
             component={Link}
-            href={result.href}
+            to={result.href}
             onClick={onClick}
           >
             {result.node}

--- a/libs/components/src/lib/ShiftCard.tsx
+++ b/libs/components/src/lib/ShiftCard.tsx
@@ -8,13 +8,13 @@ import CardHeader from '@mui/material/CardHeader';
 import Divider from '@mui/material/Divider';
 import Grid from '@mui/material/Grid2';
 import Typography from '@mui/material/Typography';
-import Link from 'next/link';
+import { Link } from 'react-router';
 
 export function ShiftCard({ shift }: { shift: ProcessedShift }) {
   return (
     <Grid size={{ xxs: 12, md: 6, lg: 4 }}>
       <Card>
-        <CardActionArea component={Link} href={`/shift/${shift.id}`}>
+        <CardActionArea component={Link} to={`/shift/${shift.id}`}>
           <CardHeader
             title={shift.shift_title}
             subheader={`${shift.shift_start.format(

--- a/libs/components/src/lib/ShiftView.tsx
+++ b/libs/components/src/lib/ShiftView.tsx
@@ -6,7 +6,7 @@ import CardContent from '@mui/material/CardContent';
 import LinearProgress from '@mui/material/LinearProgress';
 import Link from '@mui/material/Link';
 import Typography from '@mui/material/Typography';
-import NextLink from 'next/link';
+import { Link as RouterLink } from 'react-router';
 
 import { ShiftCard } from './ShiftCard';
 
@@ -24,7 +24,7 @@ export function ShiftView({ id }: { id: string }) {
       <>
         <Breadcrumbs aria-label="breadcrumb">
           <Link
-            component={NextLink}
+            component={RouterLink}
             underline="hover"
             color="inherit"
             href={`/volunteer-shifts`}

--- a/libs/components/src/lib/ShiftView.tsx
+++ b/libs/components/src/lib/ShiftView.tsx
@@ -27,7 +27,7 @@ export function ShiftView({ id }: { id: string }) {
             component={RouterLink}
             underline="hover"
             color="inherit"
-            href={`/volunteer-shifts`}
+            to={`/volunteer-shifts`}
           >
             Upcoming Shifts
           </Link>

--- a/libs/components/src/lib/VehicleCard.tsx
+++ b/libs/components/src/lib/VehicleCard.tsx
@@ -5,12 +5,12 @@ import ButtonBase from '@mui/material/ButtonBase';
 import Grid from '@mui/material/Grid2';
 import Paper from '@mui/material/Paper';
 import Typography from '@mui/material/Typography';
-import Link from 'next/link';
+import { Link } from 'react-router';
 
 export function VehicleCard({ vehicle }: { vehicle: VehicleItem }) {
   return (
     <Grid size={{ xxs: 12, md: 6, lg: 4 }}>
-      <ButtonBase component={Link} href={`/vehicles/${vehicle.id}`}>
+      <ButtonBase component={Link} to={`/vehicles/${vehicle.id}`}>
         <Paper sx={{ padding: 2 }}>
           <Typography variant="h5">{vehicle.title}</Typography>
           <Typography variant="subtitle1">

--- a/libs/pages/src/lib/art-item/index.tsx
+++ b/libs/pages/src/lib/art-item/index.tsx
@@ -3,8 +3,10 @@ import { Header } from '@digital-www-pwa/components';
 import { useArt, useLocation } from '@digital-www-pwa/providers';
 import Skeleton from '@mui/material/Skeleton';
 import Typography from '@mui/material/Typography';
+import { useParams } from 'react-router';
 
-export function ArtItemPage({ id }: { id: string }) {
+export function ArtItemPage() {
+  const { id } = useParams();
   const art = useArt(id);
   const location = useLocation(art?.location);
 

--- a/libs/pages/src/lib/camps-item/index.tsx
+++ b/libs/pages/src/lib/camps-item/index.tsx
@@ -4,8 +4,10 @@ import { EventsView } from '@digital-www-pwa/components';
 import { useCamp } from '@digital-www-pwa/providers';
 import Skeleton from '@mui/material/Skeleton';
 import Typography from '@mui/material/Typography';
+import { useParams } from 'react-router';
 
-export function CampsItemPage({ id }: { id: string }) {
+export function CampsItemPage() {
+  const { id } = useParams();
   const camp = useCamp(id);
 
   const renderCampEvents = () => {

--- a/libs/pages/src/lib/events-item/index.tsx
+++ b/libs/pages/src/lib/events-item/index.tsx
@@ -88,7 +88,7 @@ export function EventsItemPage() {
         </Link>
       );
     }
-    return eventTime.event.where_name;
+    return eventTime.event.where_name || eventTime.event.who_name;
   }
 
   return (

--- a/libs/pages/src/lib/events-item/index.tsx
+++ b/libs/pages/src/lib/events-item/index.tsx
@@ -14,8 +14,8 @@ import ListItemIcon from '@mui/material/ListItemIcon';
 import ListItemText from '@mui/material/ListItemText';
 import Skeleton from '@mui/material/Skeleton';
 import Typography from '@mui/material/Typography';
-import NextLink from 'next/link';
 import { ElementType, useMemo } from 'react';
+import { Link as RouterLink, useParams } from 'react-router';
 
 function formatEventTime(eventTime: ProcessedEventTime) {
   return eventTime.all_day
@@ -25,7 +25,8 @@ function formatEventTime(eventTime: ProcessedEventTime) {
       )}`;
 }
 
-export function EventsItemPage({ id }: { id: string }) {
+export function EventsItemPage() {
+  const { id } = useParams();
   const eventTime = useEventTime(id);
   const camps = useCamps();
 
@@ -62,7 +63,7 @@ export function EventsItemPage({ id }: { id: string }) {
         {otherTimes.map((otherTime) => (
           <ListItem key={otherTime.event_time_id}>
             <ListItemButton
-              component={NextLink as ElementType}
+              component={RouterLink as ElementType}
               to={`/events/${otherTime.event_time_id}`}
             >
               <ListItemIcon>
@@ -82,7 +83,7 @@ export function EventsItemPage({ id }: { id: string }) {
     }
     if (camp) {
       return (
-        <Link component={NextLink} href={`/camps/${camp.id}`}>
+        <Link component={RouterLink} to={`/camps/${camp.id}`}>
           {eventTime.event.where_name}
         </Link>
       );

--- a/libs/pages/src/lib/happening-now/index.tsx
+++ b/libs/pages/src/lib/happening-now/index.tsx
@@ -3,13 +3,13 @@ import { EventsView } from '@digital-www-pwa/components';
 import { EVENT_START, EVENT_END } from '@digital-www-pwa/utils';
 import dayjs from 'dayjs';
 import isBetween from 'dayjs/plugin/isBetween';
-import { useRouter } from 'next/navigation';
+import { useNavigate } from 'react-router';
 import { useEffect, useState } from 'react';
 
 dayjs.extend(isBetween);
 
 export function HappeningNowPage() {
-  const router = useRouter();
+  const navigate = useNavigate();
   const [currentTime, setCurrentTime] = useState(dayjs());
 
   const updateTime = () => setCurrentTime(dayjs());
@@ -23,7 +23,7 @@ export function HappeningNowPage() {
 
   useEffect(() => {
     if (!currentTime.isBetween(EVENT_START, EVENT_END)) {
-      router.push('/');
+      navigate('/');
     }
   }, [currentTime]);
 

--- a/libs/pages/src/lib/home/index.tsx
+++ b/libs/pages/src/lib/home/index.tsx
@@ -116,11 +116,7 @@ export function HomePage() {
           </Grid>
         );
       })}
-      <Grid size={{ xxs: 12 }}>
-        <Button component={MuiLink} href={''} color="secondary">
-          Live Stream Radio SGC
-        </Button>
-      </Grid>
+      <Grid size={{ xxs: 12 }}></Grid>
       {EXTERNAL_LINKS.map((linkData) => (
         <Grid key={linkData.url} size={{ xxs: 12, sm: 6 }}>
           <Button

--- a/libs/pages/src/lib/home/index.tsx
+++ b/libs/pages/src/lib/home/index.tsx
@@ -27,6 +27,10 @@ const EXTERNAL_LINKS = [
     url: 'https://lakesoffire.org/departments/gate/',
   },
   {
+    title: 'Exodus',
+    url: 'https://lakesoffire.org/the-event/survival-guide/#:~:text=EXODUS,-All',
+  },
+  {
     title: 'Survival Guide',
     url: 'http://lakesoffire.org/the-event/survival-guide',
   },

--- a/libs/pages/src/lib/home/index.tsx
+++ b/libs/pages/src/lib/home/index.tsx
@@ -14,7 +14,18 @@ import { useTheme } from '@mui/material/styles';
 import Typography from '@mui/material/Typography';
 import dayjs from 'dayjs';
 
+const DIRECTIONS_URL =
+  'https://maps.google.com/maps/dir//Lucky+Lake+Campground+%26+Outdoor+Center+MAIL+ADDRESS:+3977+W.+Wilke+Rd+GPS:+3280+Winston+Rd.+Rothbury+49432+GPS:+3474+W.+Winston+Rd,+Rothbury+49452+Montague,+MI+49437/';
+
 const EXTERNAL_LINKS = [
+  {
+    title: 'Directions',
+    url: DIRECTIONS_URL,
+  },
+  {
+    title: 'Gate Hours',
+    url: 'https://lakesoffire.org/departments/gate/',
+  },
   {
     title: 'Survival Guide',
     url: 'http://lakesoffire.org/the-event/survival-guide',
@@ -58,7 +69,9 @@ export function HomePage() {
             >
               Doorways in Time
             </Box>
-            <Box sx={{ fontSize: '1.8rem' }}>Lucky Lake Campground</Box>
+            <MuiLink sx={{ fontSize: '1.8rem' }} href={DIRECTIONS_URL}>
+              Lucky Lake Campground
+            </MuiLink>
           </Stack>
         </Typography>
       </Grid>

--- a/libs/pages/src/lib/home/index.tsx
+++ b/libs/pages/src/lib/home/index.tsx
@@ -110,6 +110,12 @@ export function HomePage() {
         </Stack>
       </Grid>
       {NAVIGATION_LINKS.map((linkData) => {
+        if (
+          linkData.path === '/now' &&
+          !dayjs().isBetween(EVENT_START, EVENT_END)
+        ) {
+          return null;
+        }
         return (
           <Grid key={linkData.path} size={{ xxs: 12, sm: 6, md: 4 }}>
             <NavigationButton linkData={linkData} />

--- a/libs/pages/src/lib/map/index.tsx
+++ b/libs/pages/src/lib/map/index.tsx
@@ -5,6 +5,7 @@ import {
   MAP_LOCATION_ANCHORS,
   MAP_ACCURACY_SIZE_FACTOR,
   POSITION_STALE_TIME,
+  calculateDistance,
 } from '@digital-www-pwa/utils';
 import ClearIcon from '@mui/icons-material/Clear';
 import GpsFixedIcon from '@mui/icons-material/GpsFixed';
@@ -17,6 +18,7 @@ import Box from '@mui/material/Box';
 import Container from '@mui/material/Container';
 import Fab from '@mui/material/Fab';
 import Stack from '@mui/material/Stack';
+import Typography from '@mui/material/Typography';
 import { useTheme } from '@mui/material/styles';
 import { useState, useLayoutEffect, useMemo, useRef } from 'react';
 import {
@@ -28,12 +30,6 @@ import type {
   ReactZoomPanPinchContext,
   ReactZoomPanPinchHandlers,
 } from 'react-zoom-pan-pinch';
-
-function calculateDistance(a: GpsCoordinates, b: GpsCoordinates) {
-  return Math.sqrt(
-    (a.latitude - b.latitude) ** 2 + (a.longitude - b.longitude) ** 2
-  );
-}
 
 function gpsToStyle(position: GeolocationPosition | null) {
   if (!position) {
@@ -231,20 +227,37 @@ export function MapPage() {
               </Fab>
             </Stack>
             {isGeolocationSupported && (
-              <Fab
-                size="large"
-                aria-label="Locate Me"
-                onClick={() =>
-                  handleClickFindMyLocation(instance, zoomToElement)
-                }
+              <Stack
+                direction="row"
+                alignItems="center"
+                spacing={2}
                 sx={{
                   position: 'absolute',
                   right: theme.spacing(1),
                   bottom: theme.spacing(1),
                 }}
               >
-                {renderFindLocationButtonIcon()}
-              </Fab>
+                {currentPosition && !isCloseToEvent && (
+                  <Typography
+                    sx={{ padding: 1, background: 'rgba(0,0,0,0.5)' }}
+                  >
+                    {calculateDistance(
+                      currentPosition.coords,
+                      MAP_LOCATION_ANCHORS[0]
+                    ).toFixed(1)}{' '}
+                    miles
+                  </Typography>
+                )}
+                <Fab
+                  size="large"
+                  aria-label="Locate Me"
+                  onClick={() =>
+                    handleClickFindMyLocation(instance, zoomToElement)
+                  }
+                >
+                  {renderFindLocationButtonIcon()}
+                </Fab>
+              </Stack>
             )}
           </>
         )}

--- a/libs/pages/src/lib/radio-item/index.tsx
+++ b/libs/pages/src/lib/radio-item/index.tsx
@@ -3,8 +3,10 @@ import { Header } from '@digital-www-pwa/components';
 import { useRadio } from '@digital-www-pwa/providers';
 import Skeleton from '@mui/material/Skeleton';
 import Typography from '@mui/material/Typography';
+import { useParams } from 'react-router';
 
-export function RadioItemPage({ id }: { id: string }) {
+export function RadioItemPage() {
+  const { id } = useParams();
   const radio = useRadio(id);
   return (
     <>

--- a/libs/pages/src/lib/shift/index.tsx
+++ b/libs/pages/src/lib/shift/index.tsx
@@ -4,15 +4,17 @@ import { ShiftsProvider, useAuthContext } from '@digital-www-pwa/providers';
 import Button from '@mui/material/Button';
 import LinearProgress from '@mui/material/LinearProgress';
 import { useTheme } from '@mui/material/styles';
+import { useParams } from 'react-router';
 
-export function ShiftPage({ id }: { id: string }) {
+export function ShiftPage() {
+  const { id } = useParams();
   const theme = useTheme();
   const authContext = useAuthContext();
   const queryParams = new URLSearchParams({
     redirect_target: `/shift/${id}`,
   });
 
-  if (authContext.checking) {
+  if (authContext.checking || !id) {
     return (
       <>
         <Header>{'Volunteer Shifts'}</Header>

--- a/libs/pages/src/lib/vehicles-item/index.tsx
+++ b/libs/pages/src/lib/vehicles-item/index.tsx
@@ -3,8 +3,10 @@ import { Header } from '@digital-www-pwa/components';
 import { useVehicle } from '@digital-www-pwa/providers';
 import Skeleton from '@mui/material/Skeleton';
 import Typography from '@mui/material/Typography';
+import { useParams } from 'react-router';
 
-export function VehiclesItemPage({ id }: { id: string }) {
+export function VehiclesItemPage() {
+  const { id } = useParams();
   const vehicle = useVehicle(id);
   return (
     <>

--- a/libs/providers/src/lib/ProcessedDataProvider.tsx
+++ b/libs/providers/src/lib/ProcessedDataProvider.tsx
@@ -31,54 +31,54 @@ export function useEvents() {
   return useContext(ProcessedDataContext).events;
 }
 
-export function useEvent(id: string) {
+export function useEvent(id?: string) {
   const events = useEvents();
-  return events && events[id];
+  return (events && id && events[id]) || null;
 }
 
 export function useEventTimes() {
   return useContext(ProcessedDataContext).eventTimes;
 }
 
-export function useEventTime(id: string) {
+export function useEventTime(id?: string) {
   const eventTimes = useEventTimes();
-  return eventTimes && eventTimes[id];
+  return (eventTimes && id && eventTimes[id]) || null;
 }
 
 export function useArts() {
   return useContext(ProcessedDataContext).arts;
 }
 
-export function useArt(id: string) {
+export function useArt(id?: string) {
   const arts = useArts();
-  return arts && arts[id];
+  return (arts && id && arts[id]) || null;
 }
 
 export function useCamps() {
   return useContext(ProcessedDataContext).camps;
 }
 
-export function useCamp(id: string) {
+export function useCamp(id?: string) {
   const camps = useCamps();
-  return camps && camps[id];
+  return (camps && id && camps[id]) || null;
 }
 
 export function useRadios() {
   return useContext(ProcessedDataContext).radios;
 }
 
-export function useRadio(id: string) {
+export function useRadio(id?: string) {
   const radios = useRadios();
-  return radios && radios[id];
+  return (radios && id && radios[id]) || null;
 }
 
 export function useVehicles() {
   return useContext(ProcessedDataContext).vehicles;
 }
 
-export function useVehicle(id: string) {
+export function useVehicle(id?: string) {
   const vehicles = useVehicles();
-  return vehicles && vehicles[id];
+  return (vehicles && id && vehicles[id]) || null;
 }
 
 export function useLocations() {
@@ -87,7 +87,7 @@ export function useLocations() {
 
 export function useLocation(id?: string) {
   const locations = useLocations();
-  return locations && id && locations[id];
+  return (locations && id && locations[id]) || null;
 }
 
 dayjs.extend(utc);

--- a/libs/types/src/lib/event.ts
+++ b/libs/types/src/lib/event.ts
@@ -22,6 +22,8 @@ export type EventItem = {
   site_id: null;
   where_type: string;
   where_name: string;
+  who_type: string;
+  who_name: string;
   event_recurrence: EventRecurrance;
   heart_count: number;
   alcohol: boolean;

--- a/libs/utils/src/index.ts
+++ b/libs/utils/src/index.ts
@@ -1,3 +1,4 @@
-export * from './lib/utils';
-export * from './lib/theme';
 export * from './lib/const';
+export * from './lib/haversine';
+export * from './lib/theme';
+export * from './lib/utils';

--- a/libs/utils/src/lib/const.ts
+++ b/libs/utils/src/lib/const.ts
@@ -42,13 +42,11 @@ export const NAVIGATION_LINKS = [
     icon: MapIcon,
   },
   */
-  dayjs().isBetween(EVENT_START, EVENT_END)
-    ? {
-        title: 'Happening Now',
-        path: '/now',
-        icon: CampaignIcon,
-      }
-    : null,
+  {
+    title: 'Happening Now',
+    path: '/now',
+    icon: CampaignIcon,
+  },
   {
     title: 'Favorites',
     path: '/favorites',

--- a/libs/utils/src/lib/haversine.ts
+++ b/libs/utils/src/lib/haversine.ts
@@ -1,0 +1,21 @@
+import type { GpsCoordinates } from '@digital-www-pwa/types';
+
+export function calculateDistance(pos1: GpsCoordinates, pos2: GpsCoordinates) {
+  const toRadian = (angle: number) => (Math.PI / 180) * angle;
+  const distance = (a: number, b: number) => (Math.PI / 180) * (a - b);
+  const RADIUS_OF_EARTH_IN_MI = 3959;
+
+  const dLat = distance(pos2.latitude, pos1.latitude);
+  const dLon = distance(pos2.longitude, pos1.longitude);
+
+  const lat1 = toRadian(pos1.latitude);
+  const lat2 = toRadian(pos2.latitude);
+
+  // Haversine Formula
+  const a =
+    Math.pow(Math.sin(dLat / 2), 2) +
+    Math.pow(Math.sin(dLon / 2), 2) * Math.cos(lat1) * Math.cos(lat2);
+  const c = 2 * Math.asin(Math.sqrt(a));
+
+  return RADIUS_OF_EARTH_IN_MI * c;
+}

--- a/libs/utils/src/lib/theme.ts
+++ b/libs/utils/src/lib/theme.ts
@@ -237,6 +237,7 @@ export const theme = responsiveFontSizes(
               opacity: 1,
               boxShadow: 'none',
               breakInside: 'avoid',
+              border: 'none',
             },
           },
         },

--- a/package.json
+++ b/package.json
@@ -38,6 +38,7 @@
     "prop-types": "^15.8.1",
     "react": "18.3.1",
     "react-dom": "18.3.1",
+    "react-router": "^7.6.2",
     "react-split-flap-effect": "^1.0.0",
     "react-zoom-pan-pinch": "^3.7.0",
     "reflect-metadata": "^0.2.2",

--- a/yarn.lock
+++ b/yarn.lock
@@ -2567,6 +2567,7 @@ __metadata:
     prop-types: "npm:^15.8.1"
     react: "npm:18.3.1"
     react-dom: "npm:18.3.1"
+    react-router: "npm:^7.6.2"
     react-split-flap-effect: "npm:^1.0.0"
     react-zoom-pan-pinch: "npm:^3.7.0"
     reflect-metadata: "npm:^0.2.2"
@@ -7709,6 +7710,13 @@ __metadata:
   version: 0.7.1
   resolution: "cookie@npm:0.7.1"
   checksum: 10c0/5de60c67a410e7c8dc8a46a4b72eb0fe925871d057c9a5d2c0e8145c4270a4f81076de83410c4d397179744b478e33cd80ccbcc457abf40a9409ad27dcd21dde
+  languageName: node
+  linkType: hard
+
+"cookie@npm:^1.0.1":
+  version: 1.0.2
+  resolution: "cookie@npm:1.0.2"
+  checksum: 10c0/fd25fe79e8fbcfcaf6aa61cd081c55d144eeeba755206c058682257cb38c4bd6795c6620de3f064c740695bb65b7949ebb1db7a95e4636efb8357a335ad3f54b
   languageName: node
   linkType: hard
 
@@ -15148,6 +15156,22 @@ __metadata:
   languageName: node
   linkType: hard
 
+"react-router@npm:^7.6.2":
+  version: 7.6.2
+  resolution: "react-router@npm:7.6.2"
+  dependencies:
+    cookie: "npm:^1.0.1"
+    set-cookie-parser: "npm:^2.6.0"
+  peerDependencies:
+    react: ">=18"
+    react-dom: ">=18"
+  peerDependenciesMeta:
+    react-dom:
+      optional: true
+  checksum: 10c0/c8ef65f2a378f38e3cba900d67fa2b80a41c1c3925102875ee07c12faa01ea40991cb3fbefaf3ff6914e724c755732e3d7dec2b1bdef09e0fddd00fccc85a06a
+  languageName: node
+  linkType: hard
+
 "react-split-flap-effect@npm:^1.0.0":
   version: 1.0.0
   resolution: "react-split-flap-effect@npm:1.0.0"
@@ -16007,6 +16031,13 @@ __metadata:
     parseurl: "npm:~1.3.3"
     send: "npm:0.19.0"
   checksum: 10c0/528fff6f5e12d0c5a391229ad893910709bc51b5705962b09404a1d813857578149b8815f35d3ee5752f44cd378d0f31669d4b1d7e2d11f41e08283d5134bd1f
+  languageName: node
+  linkType: hard
+
+"set-cookie-parser@npm:^2.6.0":
+  version: 2.7.1
+  resolution: "set-cookie-parser@npm:2.7.1"
+  checksum: 10c0/060c198c4c92547ac15988256f445eae523f57f2ceefeccf52d30d75dedf6bff22b9c26f756bd44e8e560d44ff4ab2130b178bd2e52ef5571bf7be3bd7632d9a
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
This PR migrates us to use react router instead of the nextjs router. It bundles all of the pages into the nextjs layout file, which effectively converts the app to an SPA that doesn't require internet access after its loaded.